### PR TITLE
Use NAN_MODULE_WORKER_ENABLED to make module context aware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 build
+bin
 .DS_Store
 .clang_complete
 

--- a/src/bindings/bindings.cc
+++ b/src/bindings/bindings.cc
@@ -21,4 +21,4 @@ void Init(Local<Object> exports) {
   TextBufferSnapshotWrapper::init();
 }
 
-NODE_MODULE(superstring, Init)
+NAN_MODULE_WORKER_ENABLED(superstring, Init)


### PR DESCRIPTION
All native modules used in Electron need to be context-ware before when upgrading to Electron 14. [ref](https://github.com/electron/electron/issues/18397). However, `superstring` is still one of the module that isn't context-aware.

This PR uses `NAN_MODULE_WORKER_ENABLED` instead of `NODE_MODULE` to make the module context-aware.

Please check https://github.com/electron/electron/issues/18397 and https://github.com/nodejs/nan/pull/792 for more detail.

Testing was done locally.