### PR TITLE
src: Include cstdint in regex.h (fix building on g++ 13)

### DIFF
--- a/src/core/regex.h
+++ b/src/core/regex.h
@@ -1,6 +1,7 @@
 #ifndef REGEX_H_
 #define REGEX_H_
 
+#include <cstdint>
 #include "optional.h"
 #include <string>
 


### PR DESCRIPTION
I basically don't know anything about C or C++, other than this fixes the compilation error on g++ 13.

I think there's some controversy as to whether including standard library stuff in this manner is a good idea, per StackOverflow?? Something about polluting namespaces?? https://stackoverflow.com/questions/13642827/cstdint-vs-stdint-h If someone more knowledgeable or experienced with C/C++ could weigh in, that'd be great, and I'd much appreciate it.

Tested working in an Ubuntu 23.10 Docker container. ~~**Would be nice to see this compile on macOS and Windows, too.**~~ (EDIT: Okay, it's working on all three OSes, phew. I can breathe easier about that now. Failure on Windows with Node 14 is unrelated to the current PR, I figured it out in another PR, see comment here: https://github.com/pulsar-edit/superstring/pull/6#issuecomment-1777757302. I have a commit in that PR branch with a fix.)

Credit to these folks for the solution: https://github.com/EdgeTX/edgetx/issues/3222. I just copied what they did, to be quite honest. (See the PR that shows as mentioning that issue a little down in the thread. That's where they implemented the fix I copied. But I found the issue first, then the PR.)

**Before:**

```
[ . . . ]
  CXX(target) Release/obj.target/superstring_core/src/core/regex.o
In file included from ../src/core/regex.cc:1:
../src/core/regex.h:17:27: error: 'uint32_t' has not been declared
   17 |   Regex(const char16_t *, uint32_t, std::u16string *error_message, bool ignore_case = false, bool unicode = false);
      |                           ^~~~~~~~
../src/core/regex.cc:50:1: error: no declaration matches 'Regex::Regex(const char16_t*, uint32_t, std::u16string*, bool, bool)'
   50 | Regex::Regex(const char16_t *pattern, uint32_t pattern_length, u16string *error_message, bool ignore_case, bool unicode) {
      | ^~~~~
[ . . . ]
```

(various errors in `src/core/regex.cc` about undeclared integer functionality we're trying to use...)

**After:**

```
[ . . . ]
  CXX(target) Release/obj.target/superstring_core/src/core/point.o
  CXX(target) Release/obj.target/superstring_core/src/core/range.o
  CXX(target) Release/obj.target/superstring_core/src/core/regex.o
  CXX(target) Release/obj.target/superstring_core/src/core/text.o
  CXX(target) Release/obj.target/superstring_core/src/core/text-buffer.o
[ . . . ]
```

(regex.o output compiles without even a compiler warning, at least with whatever compiler flags node-gyp is using.)