### PR TITLE
Fix CI Again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,12 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
 
+      - name: Install Python setuptools
+        # This is needed for Python 3.12+, since many versions of node-gyp
+        # are incompatible with Python 3.12+, which no-longer ships 'distutils'
+        # out of the box. 'setuptools' package provides 'distutils'.
+        run: python3 -m pip install setuptools
+
       - name: Install dependencies
         run: npm install
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            'node_modules'
+            node_modules
           key: ${{ runner.os }}-${{ matrix.node_version }}-${{ hashFiles('package.json') }}
 
       - name: Setup node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,18 +27,18 @@ jobs:
     name: Node ${{ matrix.node_version }} on ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             'node_modules'
           key: ${{ runner.os }}-${{ matrix.node_version }}-${{ hashFiles('package.json') }}
 
       - name: Setup node
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node_version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,16 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
 
+      - name: Setup python
+        if: matrix.node_version == 14
+        # Old versions of Node bundle old versions of npm.
+        # Old versions of npm bundle old versions of node-gyp.
+        # Old versions of node-gyp are incompatible with Python 3.11+.
+        # Install older Python (Python 3.10) as a workaround.
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
       - name: Install Python setuptools
         # This is needed for Python 3.12+, since many versions of node-gyp
         # are incompatible with Python 3.12+, which no-longer ships 'distutils'


### PR DESCRIPTION
## Fixing CI, Again

This is working around some stuff, mostly to do with older versions of node-gyp we're running that need workarounds for newer Python versions.

## Changes, and Rationale for Changes

Changes (with rationale in the nested bullet points):

- **Install older Python (Python 3.10) for the Node 14 jobs**
  - Rationale: Node 14 comes with npm 6, which comes with node-gyp 5, which is incompatible with Python 3.11+.
  - The issue this works around is fixed in gyp-next 0.7.0, which is included in node-gyp 8.0.0, which is included in npm 8.0.0. Newer npm than 8.0.0 shouldn't require this workaround.
  - Latest Node 16 (Node 16.20.2) comes with npm 8.19.4, so the workaround isn't needed other than on older Node 14
- **Install Python package 'setuptools', which provides the 'distutils' module, which is needed with Python 3.12+**
  - GitHub Actions' GitHub-hosted macOS runner base images started using Python 3.12 by default recently.
  - Presumably, the runner images for Ubuntu and Windows will also switch to this newer Python version eventually.
  - Pretty much a no-op on older Python, so it's very low-to-no-risk on older Python. The step `python3 -m pip install setuptools` simply says the 'setuptools' requirement is already satisfied, since 'setuptools' used to be bundled out of the box with these older versions of Python. It was only deprecated in Python 3.10 (if I recall correctly), and then removed in Python 3.12.
- **Update all `actions/xyz` actions to the latest semver-major versions**
  - **This change is optional, CI works without it.**
  - These actions run on newer NodeJS -- GitHub Actions occasionally raises the minimum NodeJS version actions can run on, so this is keeping ahead of the curve for our CI dependencies becoming deprecated or disabled in the future, forcing the upgrade then. Better to keep up now, IMO and avoid being surprised, or being stuck in a corner if the upgrade wouldn't go smoothly then.
  - These newer actions may have desirable bug-fixes I suppose??
  - To be honest, I just thought it was weird we were still on `actions/setup-node@v2-beta`. That action has had stable v2 and even v3 for a _long_ time now.
- **Tweak the syntax of the 'path' to not include quotation marks for `actions/cache`**
  - **Optional change, this is only useful/needed if keeping the change above that upgrades the semver major versions of `actions/xyz` actions.**
  - This change is required as of the `actions/cache@v3` update I just did in this PR branch. Otherwise, it fails to find a path literally named `'node_modules'`, (as if the single quote characters were literally part of the path name, not semantic quotes) and doesn't upload/restore any cache.
  - Caching is kind of pointless the way it's set up in this workflow right now, since it does `npm install` regardless of if the cache was restored or not, and most of the time spent during `npm install` is rebuilding the native C/C++ code anyway -- It's unclear to me if caching saves any time whatsoever, as CI runtime is much more dependent on how quickly the CI VMs compile the native code twice throughout the run. Which appears to be extremely variable, probably dependent on how hard other VMs running on the same hardware use the CPU/storage/network, etc. concurrently with this repo's jobs.
  - We might want to avoid doing `npm install` if cache restored successfully, but I didn't go for that optimization yet.
  - We might just as well disable caching, as installing the dependencies doesn't take that long, and caching in CI can cause surprising yet obscure and hard-to-notice-and-debug issues, if not done carefully. Is it worth saving a couple minutes (Windows) or ~20 seconds (Ubuntu) per run, if it might cause obscure issues down the line? Hmm. By the way, some of the runs with restored caches took _longer_ than ones with no restored cache. So yeah, the cache is not a straight-forward benefit for this repo's CI, at least not the way it's set up right now.

## Short summary

tl;dr:

Given that GitHub Actions only finally saw fit to start using the newer macOS images for this repo, with Python 3.12, these fixes were not needed until right about now. So, without us changing anything, the newer image broke this repo's CI, and this fixes it. Also some housekeeping upgrading the `actions/xyz` actions to their latest semver versions at the time of this PR being opened.

**Yeah, it is kind of annoying that Python keeps breaking node-gyp, and that node-gyp keeps on having to change to keep up. What more can I say about that?**