### PR TITLE
Move 'node-addon-api' to dependencies rather than devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
       "name": "@pulsar-edit/superstring",
       "version": "3.0.1",
       "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.5.0"
+      },
       "devDependencies": {
         "chai": "^2.0.0",
         "mocha": "^2.3.4",
-        "node-addon-api": "^8.5.0",
         "random-seed": "^0.2.0",
         "standard": "^4.5.4",
         "temp": "^0.8.3",
@@ -2520,7 +2522,6 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
       "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
-      "dev": true,
       "engines": {
         "node": "^18 || ^20 || >= 21"
       }
@@ -6106,8 +6107,7 @@
     "node-addon-api": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
-      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
-      "dev": true
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A=="
     },
     "nopt": {
       "version": "7.2.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "devDependencies": {
     "chai": "^2.0.0",
     "mocha": "^2.3.4",
-    "node-addon-api": "^8.5.0",
     "random-seed": "^0.2.0",
     "standard": "^4.5.4",
     "temp": "^0.8.3",
@@ -48,5 +47,8 @@
       "it",
       "expect"
     ]
+  },
+  "dependencies": {
+    "node-addon-api": "^8.5.0"
   }
 }


### PR DESCRIPTION
We published `superstring` the other day, and the publish went fine, but actually installing it doesn't work. I screwed up and left `node-addon-api` in `devDependencies` — when it's actually needed for installation, since native module compilation happens as an installation task.

This should fix it.

I don't think I'll wait for a review on this one; just doing it as a PR for visibility.